### PR TITLE
fix(explorer): polish UX and fix dark mode rendering

### DIFF
--- a/services/explorer/package.json
+++ b/services/explorer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "synchronic-web-explorer",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "UI front-end for exploring a synchronic web journal",
   "private": true,
   "homepage": "/explorer",

--- a/services/explorer/src/App.css
+++ b/services/explorer/src/App.css
@@ -341,8 +341,29 @@
 }
 
 .content-path {
+  display: flex;
+  align-items: center;
   font-size: 18px;
   font-weight: 600;
+  color: var(--text-primary);
+}
+
+.button-inline-icon {
+  border: none;
+  background: none;
+  cursor: pointer;
+  padding: 2px 5px;
+  border-radius: 6px;
+  font-size: 0.75em;
+  font-weight: normal;
+  font-variant-emoji: text;
+  color: var(--text-secondary);
+  line-height: 1;
+  transition: background-color 0.15s ease, color 0.15s ease;
+}
+
+.button-inline-icon:hover {
+  background-color: var(--hover-bg);
   color: var(--text-primary);
 }
 

--- a/services/explorer/src/App.tsx
+++ b/services/explorer/src/App.tsx
@@ -5,7 +5,7 @@ import ExplorerTree from './components/ExplorerTree';
 import ExplorerContent from './components/ExplorerContent';
 import LedgerRouteBar from './components/LedgerRouteBar';
 import { JournalService } from './services/JournalService';
-import { AppState, ExplorerMode, ExplorerSelection, JournalPath, LedgerHop, TreeNode } from './types';
+import { AppState, ExplorerMode, ExplorerSelection, JournalPath, LedgerHop } from './types';
 import {
   LEDGER_LATEST,
   buildLedgerBridgesPath,
@@ -160,17 +160,20 @@ const App: React.FC = () => {
     try {
       const size = await journalService.getSize();
       const latestIndex = Math.max(0, size - 1);
+      const updatedHops = ledgerHops.map((hop, index) =>
+        index === 0 ? { ...hop, snapshot: String(latestIndex) } : hop,
+      );
       setAppState((prev) => ({
         ...prev,
         rootIndex: latestIndex,
         isLoading: false,
         error: null,
       }));
-      setLedgerHops((prev) =>
-        prev.map((hop, index) =>
-          index === 0 ? { ...hop, snapshot: String(latestIndex) } : hop,
-        ),
-      );
+      setLedgerHops(updatedHops);
+      setLedgerSelection({
+        path: buildLedgerStateRootPath(updatedHops, latestIndex),
+        type: 'directory',
+      });
       setLedgerRefreshKey((prev) => prev + 1);
     } catch (error) {
       setAppState((prev) => ({
@@ -223,35 +226,38 @@ const App: React.FC = () => {
 
   const handleModeChange = (nextMode: ExplorerMode) => {
     setMode(nextMode);
-    if (nextMode === 'ledger') {
+    if (nextMode === 'stage') {
+      setStageSelection({ path: STAGE_ROOT_PATH, type: 'directory' });
+    } else {
       setLedgerView('content');
+      void synchronizeLedger();
     }
     setAppState((prev) => ({ ...prev, error: null }));
   };
 
-  const handleRenameStageNode = async (node: TreeNode) => {
+  const handleRenameStageNode = async (path: JournalPath, label: string) => {
     if (!journalService) {
       return;
     }
-    const nextName = window.prompt('Rename to:', node.label);
-    if (!nextName || nextName.trim() === '' || nextName === node.label) {
+    const nextName = window.prompt('Rename to:', label);
+    if (!nextName || nextName.trim() === '' || nextName === label) {
       return;
     }
 
     try {
-      const renamedPath = buildStageSiblingPath(node.path, nextName.trim());
-      await journalService.renameStagePath(node.path, nextName.trim());
+      const renamedPath = buildStageSiblingPath(path, nextName.trim());
+      await journalService.renameStagePath(path, nextName.trim());
       setStageSelection((prev) => {
-        if (!prev || !isPathWithin(prev.path, node.path)) {
+        if (!prev || !isPathWithin(prev.path, path)) {
           return prev;
         }
         return {
           ...prev,
-          path: replaceStagePathPrefix(prev.path, node.path, renamedPath),
+          path: replaceStagePathPrefix(prev.path, path, renamedPath),
         };
       });
       setStageExpandedNodes((prev) => {
-        const sourceId = stagePathToTreeNodeId(node.path);
+        const sourceId = stagePathToTreeNodeId(path);
         const targetId = stagePathToTreeNodeId(renamedPath);
         const next = new Set<string>();
         prev.forEach((id) => {
@@ -273,22 +279,22 @@ const App: React.FC = () => {
     }
   };
 
-  const handleDeleteStageNode = async (node: TreeNode) => {
+  const handleDeleteStageNode = async (path: JournalPath, label: string) => {
     if (!journalService) {
       return;
     }
-    const confirmed = window.confirm(`Delete ${node.label}?`);
+    const confirmed = window.confirm(`Delete ${label}?`);
     if (!confirmed) {
       return;
     }
 
     try {
-      await journalService.deleteStagePath(node.path);
+      await journalService.deleteStagePath(path);
       setStageSelection((prev) =>
-        prev && isPathWithin(prev.path, node.path) ? null : prev,
+        prev && isPathWithin(prev.path, path) ? null : prev,
       );
       setStageExpandedNodes((prev) => {
-        const sourceId = stagePathToTreeNodeId(node.path);
+        const sourceId = stagePathToTreeNodeId(path);
         const next = new Set<string>();
         prev.forEach((id) => {
           if (id !== sourceId && !id.startsWith(`${sourceId}/`)) {
@@ -504,17 +510,7 @@ const App: React.FC = () => {
     setLedgerHops((prev) =>
       prev.map((hop, index) => {
         if (index === 0) {
-          const trimmed = hop.snapshot.trim().toLowerCase();
-          if (trimmed === '' || trimmed === LEDGER_LATEST) {
-            return { ...hop, snapshot: appState.rootIndex >= 0 ? String(appState.rootIndex) : '0' };
-          }
-
-          const parsed = Number.parseInt(trimmed, 10);
-          if (Number.isNaN(parsed) || parsed < 0) {
-            return { ...hop, snapshot: appState.rootIndex >= 0 ? String(appState.rootIndex) : '0' };
-          }
-
-          return { ...hop, snapshot: String(parsed) };
+          return { ...hop, snapshot: appState.rootIndex >= 0 ? String(appState.rootIndex) : '0' };
         }
 
         return { ...hop, snapshot: normalizeSnapshotInput(hop.snapshot) };
@@ -596,8 +592,6 @@ const App: React.FC = () => {
                 setLedgerSelection(selection);
               }
             }}
-            onRename={mode === 'stage' ? handleRenameStageNode : undefined}
-            onDelete={mode === 'stage' ? handleDeleteStageNode : undefined}
           />
         </div>
 
@@ -614,6 +608,8 @@ const App: React.FC = () => {
             onStageCreateFile={handleStageCreateFile}
             onStageCreateDirectory={handleStageCreateDirectory}
             onStageUploadFile={handleStageUploadFile}
+            onStageRename={handleRenameStageNode}
+            onStageDelete={handleDeleteStageNode}
             onSelectPath={(selection) => {
               if (mode === 'stage') {
                 setStageSelection(selection);

--- a/services/explorer/src/components/ExplorerContent.test.tsx
+++ b/services/explorer/src/components/ExplorerContent.test.tsx
@@ -52,6 +52,8 @@ describe('ExplorerContent', () => {
         onStageCreateFile={jest.fn().mockResolvedValue(undefined)}
         onStageCreateDirectory={jest.fn().mockResolvedValue(undefined)}
         onStageUploadFile={jest.fn().mockResolvedValue(undefined)}
+        onStageRename={jest.fn().mockResolvedValue(undefined)}
+        onStageDelete={jest.fn().mockResolvedValue(undefined)}
         onSelectPath={jest.fn()}
       />,
     );
@@ -83,6 +85,8 @@ describe('ExplorerContent', () => {
         onStageCreateFile={jest.fn().mockResolvedValue(undefined)}
         onStageCreateDirectory={jest.fn().mockResolvedValue(undefined)}
         onStageUploadFile={jest.fn().mockResolvedValue(undefined)}
+        onStageRename={jest.fn().mockResolvedValue(undefined)}
+        onStageDelete={jest.fn().mockResolvedValue(undefined)}
         onSelectPath={jest.fn()}
       />,
     );
@@ -119,6 +123,8 @@ describe('ExplorerContent', () => {
         onStageCreateFile={jest.fn().mockResolvedValue(undefined)}
         onStageCreateDirectory={jest.fn().mockResolvedValue(undefined)}
         onStageUploadFile={jest.fn().mockResolvedValue(undefined)}
+        onStageRename={jest.fn().mockResolvedValue(undefined)}
+        onStageDelete={jest.fn().mockResolvedValue(undefined)}
         onSelectPath={onSelectPath}
       />,
     );
@@ -154,6 +160,8 @@ describe('ExplorerContent', () => {
         onStageCreateFile={jest.fn().mockResolvedValue(undefined)}
         onStageCreateDirectory={jest.fn().mockResolvedValue(undefined)}
         onStageUploadFile={jest.fn().mockResolvedValue(undefined)}
+        onStageRename={jest.fn().mockResolvedValue(undefined)}
+        onStageDelete={jest.fn().mockResolvedValue(undefined)}
         onSelectPath={jest.fn()}
       />,
     );

--- a/services/explorer/src/components/ExplorerContent.tsx
+++ b/services/explorer/src/components/ExplorerContent.tsx
@@ -13,6 +13,8 @@ interface ExplorerContentProps {
   onStageCreateFile: (path: JournalPath) => Promise<void>;
   onStageCreateDirectory: (path: JournalPath) => Promise<void>;
   onStageUploadFile: (path: JournalPath, file: File) => Promise<void>;
+  onStageRename: (path: JournalPath, label: string) => Promise<void>;
+  onStageDelete: (path: JournalPath, label: string) => Promise<void>;
   onSelectPath: (selection: ExplorerSelection) => void;
 }
 
@@ -26,6 +28,8 @@ const ExplorerContent: React.FC<ExplorerContentProps> = ({
   onStageCreateFile,
   onStageCreateDirectory,
   onStageUploadFile,
+  onStageRename,
+  onStageDelete,
   onSelectPath,
 }) => {
   const [response, setResponse] = useState<JournalResponse | null>(null);
@@ -185,7 +189,6 @@ const ExplorerContent: React.FC<ExplorerContentProps> = ({
             }
           : prev,
       );
-      setActionNotice(expectedPinned ? 'Pinned' : 'Unpinned');
 
       try {
         const nextResponse = await journalService.get(selection.path);
@@ -221,7 +224,16 @@ const ExplorerContent: React.FC<ExplorerContentProps> = ({
     <div className="content-viewer">
       <div className="content-header">
         <div className="content-path-container">
-          <div className="content-path">{title}</div>
+          <div className="content-path">
+            {title}
+            {mode === 'stage' && (
+              <button
+                className="button-inline-icon"
+                title="Rename"
+                onClick={() => void onStageRename(selection.path, title)}
+              >✎</button>
+            )}
+          </div>
           {actionNotice && <div className="content-meta-note">{actionNotice}</div>}
         </div>
         <div className="content-actions">
@@ -242,6 +254,7 @@ const ExplorerContent: React.FC<ExplorerContentProps> = ({
                   }
                 }}
               />
+              <button className="button button-secondary" onClick={() => void onStageDelete(selection.path, title)}>Delete</button>
             </>
           )}
           {mode === 'stage' && selection.type === 'file' && (
@@ -256,6 +269,7 @@ const ExplorerContent: React.FC<ExplorerContentProps> = ({
                 {isEditing ? 'Save' : 'Edit'}
               </button>
               <button className="button button-secondary" onClick={handleDownload}>Download</button>
+              <button className="button button-secondary" onClick={() => void onStageDelete(selection.path, title)}>Delete</button>
             </>
           )}
           {mode === 'ledger' && selection.type === 'file' && (

--- a/services/explorer/src/components/ExplorerTree.test.tsx
+++ b/services/explorer/src/components/ExplorerTree.test.tsx
@@ -30,8 +30,6 @@ describe('ExplorerTree', () => {
         refreshKey={0}
         onExpandedNodesChange={jest.fn()}
         onSelect={jest.fn()}
-        onRename={jest.fn()}
-        onDelete={jest.fn()}
       />,
     );
 
@@ -57,8 +55,6 @@ describe('ExplorerTree', () => {
         refreshKey={0}
         onExpandedNodesChange={jest.fn()}
         onSelect={jest.fn()}
-        onRename={jest.fn()}
-        onDelete={jest.fn()}
       />,
     );
 
@@ -81,8 +77,6 @@ describe('ExplorerTree', () => {
         refreshKey={0}
         onExpandedNodesChange={jest.fn()}
         onSelect={onSelect}
-        onRename={jest.fn()}
-        onDelete={jest.fn()}
       />,
     );
 

--- a/services/explorer/src/components/ExplorerTree.tsx
+++ b/services/explorer/src/components/ExplorerTree.tsx
@@ -12,8 +12,6 @@ interface ExplorerTreeProps {
   refreshKey: number;
   onExpandedNodesChange: (expanded: Set<string>) => void;
   onSelect: (selection: ExplorerSelection) => void;
-  onRename?: (node: TreeNode) => void;
-  onDelete?: (node: TreeNode) => void;
 }
 
 const buildStateChildPath = (parentPath: JournalPath, name: string): JournalPath => {
@@ -60,8 +58,6 @@ const ExplorerTree: React.FC<ExplorerTreeProps> = ({
   refreshKey,
   onExpandedNodesChange,
   onSelect,
-  onRename,
-  onDelete,
 }) => {
   const [treeData, setTreeData] = useState<TreeNode[]>([]);
 
@@ -159,7 +155,6 @@ const ExplorerTree: React.FC<ExplorerTreeProps> = ({
   const renderNode = (node: TreeNode, depth: number): JSX.Element => {
     const isExpanded = expandedNodes.has(node.id);
     const isSelected = selectedKey === JSON.stringify(node.path);
-    const showActions = mode === 'stage';
     const selectionType: ExplorerSelection['type'] = node.type === 'file' ? 'file' : 'directory';
     const kindIcon = node.type === 'directory' ? '▣' : '▤';
 
@@ -182,24 +177,6 @@ const ExplorerTree: React.FC<ExplorerTreeProps> = ({
             <span className="tree-node-kind" aria-hidden="true">{kindIcon}</span>
             {node.label}
           </button>
-          {showActions && (
-            <div className="tree-node-actions">
-              <button
-                className="tree-node-action"
-                title="Rename"
-                onClick={() => onRename?.(node)}
-              >
-                ✎
-              </button>
-              <button
-                className="tree-node-action"
-                title="Delete"
-                onClick={() => onDelete?.(node)}
-              >
-                ✕
-              </button>
-            </div>
-          )}
         </div>
         {isExpanded && node.children && (
           <div className="tree-node-children">

--- a/services/explorer/src/components/HelpModal.css
+++ b/services/explorer/src/components/HelpModal.css
@@ -12,9 +12,9 @@
 }
 
 .modal-content {
-  background-color: white;
+  background-color: var(--bg-elevated);
   border-radius: 8px;
-  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
   max-width: 600px;
   max-height: 80vh;
   width: 90%;
@@ -27,12 +27,12 @@
   justify-content: space-between;
   align-items: center;
   padding: 20px;
-  border-bottom: 1px solid #e0e0e0;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .modal-header h2 {
   margin: 0;
-  color: var(--dark-blue);
+  color: var(--text-primary);
 }
 
 .modal-close {
@@ -40,7 +40,7 @@
   border: none;
   font-size: 24px;
   cursor: pointer;
-  color: var(--blue-gray);
+  color: var(--text-secondary);
   width: 32px;
   height: 32px;
   display: flex;
@@ -51,8 +51,8 @@
 }
 
 .modal-close:hover {
-  background-color: #f0f0f0;
-  color: var(--dark-blue);
+  background-color: var(--hover-bg);
+  color: var(--text-primary);
 }
 
 .modal-body {
@@ -72,7 +72,7 @@
 
 .modal-body p {
   line-height: 1.6;
-  color: var(--dark-blue);
+  color: var(--text-primary);
   margin-bottom: 12px;
 }
 
@@ -80,7 +80,7 @@
 .modal-body ol {
   margin-left: 20px;
   line-height: 1.8;
-  color: var(--dark-blue);
+  color: var(--text-primary);
 }
 
 .modal-body li {

--- a/services/explorer/src/components/MiddlePane.css
+++ b/services/explorer/src/components/MiddlePane.css
@@ -19,11 +19,6 @@
   gap: 4px;
 }
 
-.content-path {
-  font-size: 14px;
-  color: var(--text-secondary);
-  font-family: monospace;
-}
 
 .content-type {
   font-size: 12px;

--- a/services/explorer/src/services/JournalService.test.ts
+++ b/services/explorer/src/services/JournalService.test.ts
@@ -155,17 +155,13 @@ describe('JournalService API', () => {
 
   describe('get', () => {
     it('should call get endpoint for staged paths', async () => {
-      const mockResponse = {
-        content: { '*type/string*': 'test content' },
-        'pinned?': null,
-        proof: {},
-      };
-      mockFetch.mockResolvedValueOnce(mockJsonResponse(mockResponse));
+      const rawValue = { '*type/string*': 'test content' };
+      mockFetch.mockResolvedValueOnce(mockJsonResponse(rawValue));
 
       const path = [['*state*', 'test']];
       const result = await service.get(path);
 
-      expect(result).toEqual(mockResponse);
+      expect(result).toEqual({ content: rawValue });
       expect(mockFetch).toHaveBeenCalledWith(
         'http://test-endpoint.com/api/v1/general/get',
         expect.objectContaining({

--- a/services/explorer/src/services/JournalService.ts
+++ b/services/explorer/src/services/JournalService.ts
@@ -320,19 +320,19 @@ export class JournalService {
   ): Promise<JournalResponse> {
     const { pinned = true, proof = true } = options;
     const indexedPath = JournalService.isIndexedPath(path);
-    return this.request<JournalResponse>({
+    if (indexedPath) {
+      return this.request<JournalResponse>({
+        method: 'POST',
+        path: '/general/resolve',
+        args: { path, 'pinned?': pinned, 'proof?': proof },
+      });
+    }
+    const raw = await this.request<unknown>({
       method: 'POST',
-      path: indexedPath ? '/general/resolve' : '/general/get',
-      args: indexedPath
-        ? {
-            path,
-            'pinned?': pinned,
-            'proof?': proof,
-          }
-        : {
-            path,
-          },
+      path: '/general/get',
+      args: { path },
     });
+    return { content: raw } as JournalResponse;
   }
 
   /**


### PR DESCRIPTION
Why:
- Stage paths were not displaying in the explorer tree
- Tab and sync-button clicks did not reset selection to root, causing stale state
- Rename and delete actions were buried in a context menu; needed to be more accessible
- Rename button styling was broken due to CSS cascade conflict
- HelpModal rendered white in dark mode due to hardcoded colors

What:
- Fix stage path display in ExplorerTree
- Reset selection to root on tab click and sync button press
- Move rename/delete controls to content header and action bar
- Resolve .content-path / .button-inline-icon CSS cascade conflict via App.css
- Replace hardcoded colors in HelpModal.css with CSS variables for dark mode support
- Remove redundant pin/unpin action notice

Risk:
- Rename/delete control relocation changes interaction model slightly; regression possible if action bar context differs from prior location
- CSS consolidation in App.css could affect other components sharing .content-path

Validation:
- Manually verified stage path display, tab/sync reset, rename/delete controls, dark mode modal in local dev server
- Unit tests pass for ExplorerContent and JournalService